### PR TITLE
Sets default server port to 5750

### DIFF
--- a/modDatabase.bas
+++ b/modDatabase.bas
@@ -171,7 +171,7 @@ ReloadData:
             !GuildUpkeepMembers = 1000
             !GuildUpkeepSprite = 1000
 
-            !ServerPort = 5756
+            !ServerPort = 5750
 
             !Cost_Per_Durability = 100
             !Cost_Per_Strength = 100


### PR DESCRIPTION
Bug fix #8 Replace 'End' statement with cleanup

Utilized the frmMain_Unload event to close and destroy all recordsets and then changed the ShutdownServer function to call Unload frmMain instead of just End.