### PR TITLE
Bugfix/8 server shutdown closes vb when debugging

### DIFF
--- a/frmMain.frm
+++ b/frmMain.frm
@@ -802,7 +802,32 @@ LogDatShit:
 End Sub
 Private Sub menuShutdown_Click()
     ShutdownServer
-    Unload Me
+End Sub
+
+Private Sub frmMain_Unload()
+	SaveFlags
+	SaveObjects
+	
+	Dim xForm As Form
+	For Each xForm In Forms
+		If xForm.Name <> "frmMain" Then
+			Unload xForm: Set xForm = Nothing
+		End If
+	Next xForm
+	
+    UserRS.Close: Set UserRS = Nothing
+    GuildRS.Close: Set GuildRS = Nothing
+    NPCRS.Close: Set NPCRS = Nothing
+    MonsterRS.Close: Set MonsterRS = Nothing
+    ObjectRS.Close: Set ObjectRS = Nothing
+    DataRS.Close: Set DataRS = Nothing
+    MapRS.Close: Set MapRS = Nothing
+    BanRS.Close: Set BanRS = Nothing
+    PrefixRS.Close: Set PrefixRS = Nothing
+    SuffixRS.Close: Set SuffixRS = Nothing
+    MagicRS.Close: Set MagicRS = Nothing
+    DB.Close: Set DB = Nothing
+    WS.Close: Set WS = Nothing	
 End Sub
 
 Private Sub MinuteTimer_Timer()

--- a/modDatabase.bas
+++ b/modDatabase.bas
@@ -171,7 +171,7 @@ ReloadData:
             !GuildUpkeepMembers = 1000
             !GuildUpkeepSprite = 1000
 
-            !ServerPort = 5756
+            !ServerPort = 5750
 
             !Cost_Per_Durability = 100
             !Cost_Per_Strength = 100

--- a/modDatabase.bas
+++ b/modDatabase.bas
@@ -291,7 +291,6 @@ ReloadData:
     If World.LastUpdate > CLng(Date) Or Abs(World.LastUpdate - CLng(Date)) >= 30 Then
         If MsgBox("Please verify that your system date and time is set correctly -- click ok to go on.", vbOKCancel, TitleString) = vbCancel Then
             ShutdownServer
-            End
         End If
     End If
     

--- a/modServer.bas
+++ b/modServer.bas
@@ -2147,25 +2147,8 @@ Sub ShutdownServer()
             End If
         End If
     Next A
-
-    SaveFlags
-    SaveObjects
-
-    UserRS.Close
-    GuildRS.Close
-    NPCRS.Close
-    MonsterRS.Close
-    ObjectRS.Close
-    DataRS.Close
-    MapRS.Close
-    BanRS.Close
-    PrefixRS.Close
-    SuffixRS.Close
-    MagicRS.Close
-    DB.Close
-    WS.Close
-    
-    End
+	
+	Unload frmMain
 End Sub
 Sub SendToMapAllBut(ByVal MapNum As Long, ByVal Index As Long, ByVal St As String)
     Dim A As Long


### PR DESCRIPTION
Bug fix #8 Replace 'End' statement with cleanup

Utilized the frmMain_Unload event to close and destroy all recordsets and then changed the ShutdownServer function to call Unload frmMain instead of just End.